### PR TITLE
More ergonomic support for using a unix socket with a tonic server

### DIFF
--- a/examples/src/uds/server.rs
+++ b/examples/src/uds/server.rs
@@ -1,10 +1,14 @@
 #![cfg_attr(not(unix), allow(unused_imports))]
 
-use futures::TryFutureExt;
 use std::path::Path;
 #[cfg(unix)]
 use tokio::net::UnixListener;
-use tonic::{transport::Server, Request, Response, Status};
+#[cfg(unix)]
+use tokio_stream::wrappers::UnixListenerStream;
+use tonic::{
+    transport::{server::UdsConnectInfo, Server},
+    Request, Response, Status,
+};
 
 pub mod hello_world {
     tonic::include_proto!("helloworld");
@@ -26,8 +30,13 @@ impl Greeter for MyGreeter {
     ) -> Result<Response<HelloReply>, Status> {
         #[cfg(unix)]
         {
-            let conn_info = request.extensions().get::<unix::UdsConnectInfo>().unwrap();
+            let conn_info = request.extensions().get::<UdsConnectInfo>().unwrap();
             println!("Got a request {:?} with info {:?}", request, conn_info);
+
+            // Client-side unix sockets are unnamed.
+            assert!(conn_info.peer_addr.as_ref().unwrap().is_unnamed());
+            // This should contain process credentials for the client socket.
+            assert!(conn_info.peer_cred.as_ref().is_some());
         }
 
         let reply = hello_world::HelloReply {
@@ -46,87 +55,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let greeter = MyGreeter::default();
 
-    let incoming = {
-        let uds = UnixListener::bind(path)?;
-
-        async_stream::stream! {
-            loop {
-                let item = uds.accept().map_ok(|(st, _)| unix::UnixStream(st)).await;
-
-                yield item;
-            }
-        }
-    };
+    let uds = UnixListener::bind(path)?;
+    let uds_stream = UnixListenerStream::new(uds);
 
     Server::builder()
         .add_service(GreeterServer::new(greeter))
-        .serve_with_incoming(incoming)
+        .serve_with_incoming(uds_stream)
         .await?;
 
     Ok(())
-}
-
-#[cfg(unix)]
-mod unix {
-    use std::{
-        pin::Pin,
-        sync::Arc,
-        task::{Context, Poll},
-    };
-
-    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-    use tonic::transport::server::Connected;
-
-    #[derive(Debug)]
-    pub struct UnixStream(pub tokio::net::UnixStream);
-
-    impl Connected for UnixStream {
-        type ConnectInfo = UdsConnectInfo;
-
-        fn connect_info(&self) -> Self::ConnectInfo {
-            UdsConnectInfo {
-                peer_addr: self.0.peer_addr().ok().map(Arc::new),
-                peer_cred: self.0.peer_cred().ok(),
-            }
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    pub struct UdsConnectInfo {
-        pub peer_addr: Option<Arc<tokio::net::unix::SocketAddr>>,
-        pub peer_cred: Option<tokio::net::unix::UCred>,
-    }
-
-    impl AsyncRead for UnixStream {
-        fn poll_read(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &mut ReadBuf<'_>,
-        ) -> Poll<std::io::Result<()>> {
-            Pin::new(&mut self.0).poll_read(cx, buf)
-        }
-    }
-
-    impl AsyncWrite for UnixStream {
-        fn poll_write(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<std::io::Result<usize>> {
-            Pin::new(&mut self.0).poll_write(cx, buf)
-        }
-
-        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-            Pin::new(&mut self.0).poll_flush(cx)
-        }
-
-        fn poll_shutdown(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<std::io::Result<()>> {
-            Pin::new(&mut self.0).poll_shutdown(cx)
-        }
-    }
 }
 
 #[cfg(not(unix))]

--- a/tests/integration_tests/Cargo.toml
+++ b/tests/integration_tests/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.1.0"
 bytes = "1.0"
 futures-util = "0.3"
 prost = "0.9"
-tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "net"]}
+tokio = {version = "1.0", features = ["fs", "macros", "rt-multi-thread", "net"]}
 tonic = {path = "../../tonic"}
 
 [dev-dependencies]

--- a/tests/integration_tests/tests/connect_info.rs
+++ b/tests/integration_tests/tests/connect_info.rs
@@ -48,3 +48,76 @@ async fn getting_connect_info() {
 
     jh.await.unwrap();
 }
+
+#[cfg(unix)]
+pub mod unix {
+    use std::path::Path;
+
+    use futures_util::FutureExt;
+    use tokio::{
+        net::{UnixListener, UnixStream},
+        sync::oneshot,
+    };
+    use tokio_stream::wrappers::UnixListenerStream;
+    use tonic::{
+        transport::{server::UdsConnectInfo, Endpoint, Server, Uri},
+        Request, Response, Status,
+    };
+    use tower::service_fn;
+
+    use integration_tests::pb::{test_client, test_server, Input, Output};
+
+    struct Svc {}
+
+    #[tonic::async_trait]
+    impl test_server::Test for Svc {
+        async fn unary_call(&self, req: Request<Input>) -> Result<Response<Output>, Status> {
+            let conn_info = req.extensions().get::<UdsConnectInfo>().unwrap();
+
+            // Client-side unix sockets are unnamed.
+            assert!(req.remote_addr().is_none());
+            assert!(conn_info.peer_addr.as_ref().unwrap().is_unnamed());
+            // This should contain process credentials for the client socket.
+            assert!(conn_info.peer_cred.as_ref().is_some());
+
+            Ok(Response::new(Output {}))
+        }
+    }
+
+    #[tokio::test]
+    async fn getting_connect_info() {
+        let unix_socket_path = "/tmp/uds-integration-test";
+        let uds = UnixListener::bind(unix_socket_path).unwrap();
+        let uds_stream = UnixListenerStream::new(uds);
+
+        let service = test_server::TestServer::new(Svc {});
+        let (tx, rx) = oneshot::channel::<()>();
+
+        let jh = tokio::spawn(async move {
+            Server::builder()
+                .add_service(service)
+                .serve_with_incoming_shutdown(uds_stream, rx.map(drop))
+                .await
+                .unwrap();
+        });
+
+        let channel = Endpoint::try_from("http://[::]:50051")
+            .unwrap()
+            .connect_with_connector(service_fn(move |_: Uri| {
+                UnixStream::connect(unix_socket_path)
+            }))
+            .await
+            .unwrap();
+
+        let mut client = test_client::TestClient::new(channel);
+
+        client.unary_call(Input {}).await.unwrap();
+
+        tx.send(()).unwrap();
+        jh.await.unwrap();
+
+        // tokio's `UnixListener` does not cleanup the socket automatically - we need to manually
+        // remove the file at the end of the test.
+        tokio::fs::remove_file(unix_socket_path).await.unwrap();
+    }
+}

--- a/tonic/src/request.rs
+++ b/tonic/src/request.rs
@@ -202,8 +202,8 @@ impl<T> Request<T> {
     /// Get the remote address of this connection.
     ///
     /// This will return `None` if the `IO` type used
-    /// does not implement `Connected`. This currently,
-    /// only works on the server side.
+    /// does not implement `Connected` or when using a unix domain socket.
+    /// This currently only works on the server side.
     pub fn remote_addr(&self) -> Option<SocketAddr> {
         #[cfg(feature = "transport")]
         {

--- a/tonic/src/transport/server/mod.rs
+++ b/tonic/src/transport/server/mod.rs
@@ -17,6 +17,9 @@ pub use conn::TlsConnectInfo;
 #[cfg(feature = "tls")]
 use super::service::TlsAcceptor;
 
+#[cfg(unix)]
+pub use conn::UdsConnectInfo;
+
 use incoming::TcpIncoming;
 
 #[cfg(feature = "tls")]


### PR DESCRIPTION
Adds `tonic::transport::server::UdsConnectInfo` to facilitate consumers using a unix domain socket on the server side. Updates the existing `uds` example to use this `UdsConnectInfo` and tokio's `UnixListenerStream` as the latter cuts down on consumer boilerplate. Adds an integration test for `UdsConnectInfo`.

## Motivation

Currently using a unix socket requires consumers to provide an implementation of the `tonic::transport::server::Connected` trait (`UdsConnectInfo`).

When I started using `tonic`, I copy+pasted this stuff from the `uds` example into my application. I bet other users have done this as well, and while this is not the end of the world, it would be nice if unix sockets worked out of the box with a `tonic` server.

This PR aims to allow consumers to more easily use a `tokio::net::UnixListener`.

## Solution

The `UdsConnectInfo` implementation here is pulled directly from the existing `uds` example. I pulled `UnixListenerStream` into the `uds` example to remove some boilerplate code there.
